### PR TITLE
refactor: Remove volume source workaround (trading-indicators now supports it natively)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -390,15 +390,6 @@ Some indicators support additional parameters:
 
 You can apply indicators to volume data by using `source: :volume`. This is useful for analyzing volume patterns.
 
-**Important Implementation Note:** Most indicator modules (SMA, EMA, etc.) only validate price-based sources (`:close`, `:open`, `:high`, `:low`) in their parameter schemas. When using `source: :volume`, the TradingStrategy integration layer automatically handles this by:
-
-1. Removing `:volume` from validation parameters (avoiding schema errors)
-2. Extracting volume data correctly via `extract_data_series/2`
-3. Converting volume values to Decimal for precision consistency
-4. Passing the volume data to the indicator's calculation function
-
-This workaround is transparent to users and allows volume-based indicators to work seamlessly.
-
 **Example:**
 
 ```elixir
@@ -417,10 +408,6 @@ defstrategy :volume_analysis do
   end
 end
 ```
-
-**Technical Details:**
-
-The implementation is in `lib/trading_strategy/indicators.ex` at lines 144-161, where the `calculate_indicator/3` function detects `source: :volume` and modifies validation parameters accordingly. See inline comments in that file for the complete explanation.
 
 #### Helper Functions
 

--- a/lib/trading_strategy/indicators.ex
+++ b/lib/trading_strategy/indicators.ex
@@ -132,38 +132,16 @@ defmodule TradingStrategy.Indicators do
   2. Checks data sufficiency using `required_periods/0` or `required_periods/1`
   3. Handles `{:ok, results}` and `{:error, reason}` tuples
   4. Extracts value from result struct
-
-  Special handling for volume data:
-  - When `source: :volume` is specified, the source is removed from validation params
-    since most indicators only accept price-based sources
-  - Volume data is extracted and passed directly to the indicator
+  5. Supports both price-based sources (`:close`, `:open`, `:high`, `:low`) and `:volume`
   """
   @spec calculate_indicator(%{module: module(), params: keyword()}, [Types.ohlcv()], keyword()) ::
           indicator_result()
   def calculate_indicator(%{module: module, params: params}, market_data, _opts \\ []) do
-    # Special handling for volume source: Most indicators (e.g., SMA, EMA) only validate
-    # price-based sources (:close, :open, :high, :low) in their parameter schemas.
-    # When using volume as a source (e.g., `indicator :volume_sma, SMA, period: 20, source: :volume`),
-    # we need to remove :volume from validation params to avoid schema errors, while still
-    # extracting volume data correctly via extract_data_series/2.
-    validation_params =
-      case Keyword.get(params, :source) do
-        :volume ->
-          # Remove source from validation params since indicators expect price sources
-          # The data series will be volume anyway due to extract_data_series
-          Keyword.delete(params, :source)
-
-        _ ->
-          # For price sources, use params as-is for both validation and calculation
-          params
-      end
-
-    with {:ok, _} <- validate_indicator_params(module, validation_params),
+    with {:ok, _} <- validate_indicator_params(module, params),
          :ok <- check_sufficient_data(module, market_data, params),
          data <- extract_data_series(market_data, params) do
       # Call the indicator's calculate function
-      # Use validation_params (without volume source) to avoid parameter errors
-      case apply(module, :calculate, [data, validation_params]) do
+      case apply(module, :calculate, [data, params]) do
         {:ok, results} ->
           # Real indicator that follows TradingIndicators.Behaviour
           extract_indicator_value(results)


### PR DESCRIPTION
## Summary

Removes the volume source workaround from the trading-strategy library since the trading-indicators library now natively supports `source: :volume` for all indicators.

## Background

Previously, the trading-indicators library only validated price-based sources (`:close`, `:open`, `:high`, `:low`) in indicator parameter schemas. To enable volume-based indicators, the trading-strategy library implemented a workaround that:

1. Removed `:volume` from validation parameters to avoid schema errors
2. Still extracted volume data correctly via `extract_data_series/2`
3. Passed volume data to the indicator's calculation function

This workaround is no longer needed as trading-indicators now supports `:volume` as a valid source parameter.

## Changes

### `lib/trading_strategy/indicators.ex`

**Removed:**
- Special handling for `source: :volume` in `calculate_indicator/3`
- The `validation_params` variable that conditionally stripped `:volume`
- Comments explaining the workaround (lines 144-159)

**Simplified:**
- Now uses `params` directly for both validation and calculation
- Updated documentation to reflect native volume support

```elixir
# Before (with workaround)
validation_params =
  case Keyword.get(params, :source) do
    :volume -> Keyword.delete(params, :source)
    _ -> params
  end

with {:ok, _} <- validate_indicator_params(module, validation_params),
  ...
  case apply(module, :calculate, [data, validation_params]) do

# After (native support)
with {:ok, _} <- validate_indicator_params(module, params),
  ...
  case apply(module, :calculate, [data, params]) do
```

### `CLAUDE.md`

**Removed:**
- "Important Implementation Note" section explaining the workaround (lines 393-400)
- "Technical Details" section referencing the workaround implementation (lines 421-423)

**Simplified:**
- Cleaner documentation showing that volume-based indicators work natively
- Kept the example demonstrating `source: :volume` usage

## Testing

✅ **All 204 tests pass**

```bash
mix test
# 204 tests, 0 failures
```

✅ **Bollinger Bands breakout strategy with `volume_sma` works correctly**

```bash
mix run examples/debug_bollinger_breakout.exs
# Total signals: 1
# ✓ Signals generated successfully!
```

✅ **Volume-based indicators are now validated and processed directly by trading-indicators**

## Impact

**Before:**
- Volume source required workaround in trading-strategy
- Two sets of parameters: `params` and `validation_params`
- Confusing implementation with special cases

**After:**
- Clean, straightforward implementation
- Single set of parameters used throughout
- Native support from trading-indicators library
- Simpler codebase and documentation

## Breaking Changes

None. This is a pure refactoring that maintains backward compatibility. All existing code using `source: :volume` continues to work exactly as before, just without the workaround layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>